### PR TITLE
Install rpm package as part of travis ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 
 install:
     - if [ "${CXX}" == "clang++" ]; then sudo apt-get -qq install clang-3.3; fi
-    - sudo apt-get install g++-4.8;
+    - sudo apt-get install g++-4.8 rpm;
     - sudo update-alternatives --install /usr/bin/gcc-4.8 gcc /usr/bin/gcc 50
     - sudo update-alternatives --install /usr/bin/g++-4.8 g++ /usr/bin/g++ 50
     - ./CMakeScripts/install_boost.sh


### PR DESCRIPTION
Hi @daedric,

This fixes the current failure on travis-ci due to a missing rpmbuild command on the ci machines.

Cheers
Matt
