### PR TITLE
Fix timeouts when using keepalive in apache bench.

### DIFF
--- a/src/httpp/http/Utils.cpp
+++ b/src/httpp/http/Utils.cpp
@@ -35,6 +35,7 @@ void setShouldConnectionBeClosed(const Request& request, Response& response)
     if (boost::iequals(connection, KEEPALIVE))
     {
         response.connectionShouldBeClosed(false);
+        response.addHeader("Connection", KEEPALIVE);
         return;
     }
 


### PR DESCRIPTION
Set `Connection: Keep-Alive` header in response when keepalive
connection requested. According to HTTP 1.1 it is not required, because
keepalive is the default, but ab does not comply to the standard here.
So lets set it explicitly.
