### PR TITLE
Allow using external ThreadPool in HttpServer.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 PREFIX ?= /usr/local
 
 all:
-	make -C build all
+	$(MAKE) -C build all
 
 clean:
-	make -C build clean
+	$(MAKE) -C build clean
 
 cmake:
 	rm -rf build
@@ -12,9 +12,9 @@ cmake:
 	cd build && cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ..
 
 package:
-	make -C build package
+	$(MAKE) -C build package
 
 test:
-	make -C build test
+	$(MAKE) -C build test
 
 re : cmake all

--- a/include/httpp/HttpServer.hpp
+++ b/include/httpp/HttpServer.hpp
@@ -50,6 +50,7 @@ public:
 
 public:
     HttpServer(size_t threads = 1);
+    HttpServer(UTILS::ThreadPool& pool);
     ~HttpServer();
 
     void bind(const std::string& address, const std::string& port = "8000");
@@ -95,8 +96,7 @@ private: // called by Connection
 
 private:
     bool running_ = false;
-    boost::asio::io_service service_;
-    UTILS::ThreadPool pool_;
+    std::shared_ptr<UTILS::ThreadPool> pool_;
     std::atomic_int running_acceptors_ = { 0 };
     std::atomic_int connection_count_ = { 0 };
     std::vector<AcceptorPtr> acceptors_;


### PR DESCRIPTION
This way, one has direct access to the main thread pool and can schedule additional tasks.

Note: I chose to implement it so that the HttpServer owns the ThreadPool in respect to starting/stopping it (not memory-management-wise) as it was the least intrusive implementation.