### PR TITLE
Improve performance of Response::setBody

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,5 +105,11 @@ to achieve between 160K and 180K request per second with the `ping` program
 options on the same machine, this means that HTTPP overhead is about 5 to 6
 micro seconds.
 
+With a slightly more complex server that decoded the request, performed some string manipulation 
+and returned a predefined json payload, we have seen approximately 220K requests per second on 
+identical hardware, using [wrk](https://github.com/wg/wrk) to drive the load testing. 5 threads were allocated
+to the httpp server, and 3 to wrk (with 500 concurrent connections).
+
 This is scaling as threads are added but I don't have enough proper machine to
 do a real benchmark.
+

--- a/src/httpp/http/Response.cpp
+++ b/src/httpp/http/Response.cpp
@@ -88,9 +88,8 @@ Response& Response::addHeader(std::string k, std::string v)
 Response& Response::setBody(const boost::string_ref& body)
 {
     chunkedBodyCallback_ = nullptr;
-    body_.clear();
     body_.reserve(body.size());
-    std::copy(body.begin(), body.end(), std::back_inserter(body_));
+    body_.assign(std::begin(body), std::end(body));
     return *this;
 }
 


### PR DESCRIPTION
We should probably checkin some better performance test application and scripts. I'll need to modify what I tested this change against, since it's very specific to the task I need. Also I'd suggest using wrk for your perf tests, wrk seems to give better throughput than ab, esp when using on a single machine.