### PR TITLE
Fix header in ReadWholeRequest.hpp

### DIFF
--- a/include/httpp/http/helper/ReadWholeRequest.hpp
+++ b/include/httpp/http/helper/ReadWholeRequest.hpp
@@ -1,9 +1,8 @@
 #pragma once
 
-#include <cstring>
 #include <functional>
-#include <algorithm>
 #include <memory>
+#include <vector>
 
 #include <boost/system/error_code.hpp>
 

--- a/src/httpp/http/helper/ReadWholeRequest.cpp
+++ b/src/httpp/http/helper/ReadWholeRequest.cpp
@@ -1,5 +1,8 @@
 #include "httpp/http/helper/ReadWholeRequest.hpp"
 
+#include <algorithm>
+#include <cstring>
+
 #include "httpp/http/Connection.hpp"
 
 namespace HTTPP


### PR DESCRIPTION
Hi @daedric :) I experienced a compiler error on OSX where the `<vector>` header was missing. Also removed the unused `<cstring>` header. Isn't `<algorithm>` unused as well?