### PR TITLE
Expose the status code of the server Response object.

### DIFF
--- a/include/httpp/http/Response.hpp
+++ b/include/httpp/http/Response.hpp
@@ -52,6 +52,11 @@ public:
         return *this;
     }
 
+    HttpCode getCode() const noexcept
+    {
+        return code_;
+    }
+
     void clear();
 
     Response& addHeader(std::string k, std::string v);


### PR DESCRIPTION
Useful for things such as logging the response code in a central location instead of where you set it.