### PR TITLE
Initialize the allowed methods for a route

### DIFF
--- a/include/httpp/http/RestDispatcher.hpp
+++ b/include/httpp/http/RestDispatcher.hpp
@@ -45,6 +45,11 @@ struct Route
         std::function<void(HTTP::helper::ReadWholeRequest::Handle)>;
 
 public:
+    Route()
+    {
+        std::fill(allowed_method.begin(), allowed_method.end(), false);
+    }
+    
     Route& upon(HTTP::Method h);
 
     template <typename... Tail>

--- a/include/httpp/http/RestDispatcher.hpp
+++ b/include/httpp/http/RestDispatcher.hpp
@@ -47,7 +47,7 @@ struct Route
 public:
     Route()
     {
-        std::fill(allowed_method.begin(), allowed_method.end(), false);
+        allowed_method.fill(false);
     }
     
     Route& upon(HTTP::Method h);


### PR DESCRIPTION
This fixes errors with requests being routed to handlers that were not supposed to get them