### PR TITLE
Add support for WebDAV http methods

### DIFF
--- a/include/httpp/http/Protocol.hpp
+++ b/include/httpp/http/Protocol.hpp
@@ -38,14 +38,22 @@ static char const HEADER_BODY_SEP[] = { '\r', '\n', '\r', '\n' };
 
 enum class Method
 {
-    HEAD    ,
-    GET     ,
-    POST    ,
-    PUT     ,
-    DELETE_ , // '_' for msvc workaround
-    OPTIONS ,
-    TRACE   ,
-    CONNECT
+    HEAD,
+    GET,
+    POST,
+    PUT,
+    DELETE_, // '_' for msvc workaround
+    OPTIONS,
+    TRACE,
+    CONNECT,
+    // WebDAV specific methods
+    PROPFIND,
+    PROPPATCH,
+    MKCOL,
+    COPY,
+    MOVE,
+    LOCK,
+    UNLOCK,
 };
 
 std::string to_string(Method method);

--- a/src/httpp/http/Parser.cpp
+++ b/src/httpp/http/Parser.cpp
@@ -101,6 +101,30 @@ static bool parse_method(Iterator& it, Request& request)
                     return true;
                 }
             }
+            else if (*it == 'R')
+            {
+                if (!expect(it, "ROP"))
+                {
+                    return false;
+                }
+
+                if (*it == 'F')
+                {
+                    if (expect(it, "FIND"))
+                    {
+                        request.method = Method::PROPFIND;
+                        return true;
+                    }
+                }
+                else if (*it == 'P')
+                {
+                    if (expect(it, "PATCH"))
+                    {
+                        request.method = Method::PROPPATCH;
+                        return true;
+                    }
+                }
+            }
             break;
         case 'D':
             if (expect(it, "DELETE"))
@@ -123,11 +147,60 @@ static bool parse_method(Iterator& it, Request& request)
                 return true;
             }
             break;
-
-        case 'C':
-            if (expect(it, "CONNECT"))
+        case 'M':
+            ++it;
+            if (*it == 'O')
             {
-                request.method = Method::CONNECT;
+                if (expect(it, "OVE"))
+                {
+                    request.method = Method::MOVE;
+                    return true;
+                }
+            }
+            else if (*it == 'K')
+            {
+                if (expect(it, "KCOL"))
+                {
+                    request.method = Method::MKCOL;
+                    return true;
+                }
+            }
+            break;
+        case 'C':
+            ++it;
+            if (*it != 'O')
+            {
+                return false;
+            }
+            ++it;
+            if (*it == 'N')
+            {
+                if (expect(it, "NNECT"))
+                {
+                    request.method = Method::CONNECT;
+                    return true;
+                }
+            }
+            else if (*it == 'P')
+            {
+                if (expect(it, "PY"))
+                {
+                    request.method = Method::COPY;
+                    return true;
+                }
+            }
+            break;
+        case 'L':
+            if (expect(it, "LOCK"))
+            {
+                request.method = Method::LOCK;
+                return true;
+            }
+            break;
+        case 'U':
+            if (expect(it, "UNLOCK"))
+            {
+                request.method = Method::UNLOCK;
                 return true;
             }
             break;

--- a/src/httpp/http/client/Connection.cpp
+++ b/src/httpp/http/client/Connection.cpp
@@ -253,6 +253,13 @@ void Connection::configureRequest(HTTPP::HTTP::Method method)
      case HTTPP::HTTP::Method::OPTIONS:
      case HTTPP::HTTP::Method::TRACE:
      case HTTPP::HTTP::Method::CONNECT:
+     case HTTPP::HTTP::Method::PROPFIND:
+     case HTTPP::HTTP::Method::PROPPATCH:
+     case HTTPP::HTTP::Method::MKCOL:
+     case HTTPP::HTTP::Method::COPY:
+     case HTTPP::HTTP::Method::MOVE:
+     case HTTPP::HTTP::Method::LOCK:
+     case HTTPP::HTTP::Method::UNLOCK:
          std::string method_str = to_string(method);
          conn_setopt(CURLOPT_CUSTOMREQUEST, method_str.data());
          break;

--- a/src/httpp/http/parser.rl
+++ b/src/httpp/http/parser.rl
@@ -110,7 +110,7 @@ bool Parser::parse(const char* start,
     const char *token_begin, *token_end;
 
     %%{
-        method = ("GET" | "POST" | "HEAD" | "PUT" | "DELETE" | "OPTIONS" | "TRACE" | "CONNECT");
+        method = ("GET" | "POST" | "HEAD" | "PUT" | "DELETE" | "OPTIONS" | "TRACE" | "CONNECT" | "PROPFIND" | "PROPPATCH" | "MKCOL" | "COPY" | "MOVE" | "LOCK" | "UNLOCK");
 
         identifier = (alnum | '-')+;
 


### PR DESCRIPTION
I just wanted to do a small WebDAV test based on httpp. Found out that the methods defined in the WebDAV http extension are not supported by httpp atm, so I added them. Don't know whether you want them in the code base in the first place?

For details about the methods see:
http://www.webdav.org/specs/rfc2518.html
https://en.wikipedia.org/wiki/WebDAV