### PR TITLE
Do not destroy connection when endpoint cannot be found

### DIFF
--- a/src/httpp/http/Connection.cpp
+++ b/src/httpp/http/Connection.cpp
@@ -129,7 +129,6 @@ std::string Connection::source() const
 
     if (ec)
     {
-        handler_.connection_error(const_cast<Connection*>(this), ec);
         return ec.message();
     }
 


### PR DESCRIPTION
A failure in retrieving the remote endpoint causes httpp to destroy
the connection, which makes the connection invalid and causes use after
free errors in downstream code. Prevent this by just returning the error
message.

@daedric Nice greetings! And yes: We are still using this library.
